### PR TITLE
feat: Improve code coverage for String::append_utf16

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -2000,6 +2000,7 @@ CharString String::utf8(Vector<uint8_t> *r_ch_length_map) const {
 }
 
 Error String::append_utf16(const char16_t *p_utf16, int p_len, bool p_default_little_endian) {
+	// Requirement: ERR_INVALID_DATA is returned for nullptrs
 	if (!p_utf16) {
 		return ERR_INVALID_DATA;
 	}
@@ -2015,16 +2016,21 @@ Error String::append_utf16(const char16_t *p_utf16, int p_len, bool p_default_li
 	bool byteswap = !p_default_little_endian;
 #endif
 	/* HANDLE BOM (Byte Order Mark) */
+	// Requirement: for strings that are not empty, byte order marker is respected
 	if (p_len < 0 || p_len >= 1) {
 		bool has_bom = false;
+		// Requirement: forward byte order marker is respected
 		if (uint16_t(p_utf16[0]) == 0xfeff) { // correct BOM, read as is
 			has_bom = true;
 			byteswap = false;
+		// Requirement: backwards byte order marker is respected
 		} else if (uint16_t(p_utf16[0]) == 0xfffe) { // backwards BOM, swap bytes
 			has_bom = true;
 			byteswap = true;
 		}
+		// Requirement: byte order marker does not count toward string length
 		if (has_bom) {
+			// Requirement: string length cannot be negative
 			if (p_len >= 0) {
 				p_len -= 1;
 			}
@@ -2038,23 +2044,30 @@ Error String::append_utf16(const char16_t *p_utf16, int p_len, bool p_default_li
 		const char16_t *ptrtmp_limit = p_len >= 0 ? &p_utf16[p_len] : nullptr;
 		uint32_t c_prev = 0;
 		bool skip = false;
+		// Requirement: ensure surrogate character formatting is valid
 		while (ptrtmp != ptrtmp_limit && *ptrtmp) {
 			uint32_t c = (byteswap) ? BSWAP16(*ptrtmp) : *ptrtmp;
 
+			// Requirement: there can not be two lead surrogates in a row
 			if ((c & 0xfffffc00) == 0xd800) { // lead surrogate
+				// Requirement: double lead surrogate results in parse error
 				if (skip) {
 					print_unicode_error(vformat("Unpaired lead surrogate (%x [trail?] %x)", c_prev, c));
 					decode_error = true;
 				}
 				skip = true;
+			// Requirement: trail surrogate must be preceded by a lead surrogate
 			} else if ((c & 0xfffffc00) == 0xdc00) { // trail surrogate
+				// Requirement: paired trail surrogate does not increase string size
 				if (skip) {
 					str_size--;
+				// Requirement: unpaired trail surrogate results in parse error
 				} else {
 					print_unicode_error(vformat("Unpaired trail surrogate (%x [lead?] %x)", c_prev, c));
 					decode_error = true;
 				}
 				skip = false;
+			// Requirement: surrogates need to be adjacent to pair
 			} else {
 				skip = false;
 			}
@@ -2065,12 +2078,14 @@ Error String::append_utf16(const char16_t *p_utf16, int p_len, bool p_default_li
 			ptrtmp++;
 		}
 
+		// Requirement: string cannot end with a lead surrogate
 		if (skip) {
 			print_unicode_error(vformat("Unpaired lead surrogate (%x [eol])", c_prev));
 			decode_error = true;
 		}
 	}
 
+	// Requirement: OK returned for 0 size strings
 	if (str_size == 0) {
 		clear();
 		return OK; // empty string
@@ -2083,21 +2098,28 @@ Error String::append_utf16(const char16_t *p_utf16, int p_len, bool p_default_li
 
 	bool skip = false;
 	uint32_t c_prev = 0;
+	// Requirement: utf16 data is appended to string
 	while (cstr_size) {
 		uint32_t c = (byteswap) ? BSWAP16(*p_utf16) : *p_utf16;
 
+		// Requirement: only unpaired lead surrogates are appended to string
 		if ((c & 0xfffffc00) == 0xd800) { // lead surrogate
+			// Requirement: unpaired lead surrogates are appended
 			if (skip) {
 				*(dst++) = c_prev; // unpaired, store as is
 			}
 			skip = true;
+		// Requirement: only unpaired trail surrogates are appended to string
 		} else if ((c & 0xfffffc00) == 0xdc00) { // trail surrogate
+			// Requirement: paired surrogates are decoded and appended
 			if (skip) {
 				*(dst++) = (c_prev << 10UL) + c - ((0xd800 << 10UL) + 0xdc00 - 0x10000); // decode pair
+			// Requirement: unpaired trail surrogates are appended
 			} else {
 				*(dst++) = c; // unpaired, store as is
 			}
 			skip = false;
+		// Requirement: standard characters are appended to string
 		} else {
 			*(dst++) = c;
 			skip = false;
@@ -2108,12 +2130,15 @@ Error String::append_utf16(const char16_t *p_utf16, int p_len, bool p_default_li
 		c_prev = c;
 	}
 
+	// Requirement: if string ends with unpaired lead surrogate it is appended
 	if (skip) {
 		*(dst++) = c_prev;
 	}
 
+	// Requirement: parse_error is returned for strings with decode problems
 	if (decode_error) {
 		return ERR_PARSE_ERROR;
+	// Requirement: OK is returned if utf16 could be appended correctly
 	} else {
 		return OK;
 	}

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -107,22 +107,47 @@ TEST_CASE("[String] UTF8") {
 }
 
 TEST_CASE("[String] UTF16") {
-	/* how can i embed UTF in here? */
-	static const char32_t u32str[] = { 0x0045, 0x0020, 0x304A, 0x360F, 0x3088, 0x3046, 0x1F3A4, 0 };
-	static const char16_t u16str[] = { 0x0045, 0x0020, 0x304A, 0x360F, 0x3088, 0x3046, 0xD83C, 0xDFA4, 0 };
-	String expected = u32str;
-	String parsed;
-	Error err = parsed.append_utf16(expected.utf16().get_data());
-	CHECK(err == OK);
-	CHECK(parsed == u32str);
+	// Check parser correctly converts utf16 strings
+	SUBCASE("Correct conversion") {
+		/* how can i embed UTF in here? */
+		static const char32_t u32str[] = { 0x0045, 0x0020, 0x304A, 0x360F, 0x3088, 0x3046, 0x1F3A4, 0 };
+		static const char16_t u16str[] = { 0x0045, 0x0020, 0x304A, 0x360F, 0x3088, 0x3046, 0xD83C, 0xDFA4, 0 };
+		String expected = u32str;
+		String parsed;
+		Error err = parsed.append_utf16(expected.utf16().get_data());
+		CHECK(err == OK);
+		CHECK(parsed == u32str);
 
-	parsed.clear();
-	err = parsed.append_utf16(u16str);
-	CHECK(err == OK);
-	CHECK(parsed == u32str);
+		parsed.clear();
+		err = parsed.append_utf16(u16str);
+		CHECK(err == OK);
+		CHECK(parsed == u32str);
 
-	Char16String cs = u16str;
-	CHECK(String::utf16(cs) == parsed);
+		Char16String cs = u16str;
+		CHECK(String::utf16(cs) == parsed);
+	}
+
+	// Check that error is returned for nullptr data
+	SUBCASE("Invalid data") {
+		String parsed;
+		Error err = parsed.append_utf16(nullptr, 0, false);
+		CHECK(err == ERR_INVALID_DATA);
+	}
+
+	// 0 length is OK
+	SUBCASE("0 Length") {
+		String parsed;
+		Error err = parsed.append_utf16({}, 0, false);
+		CHECK(err == OK);
+	}
+
+	// Parse error for double lead surrogate
+	SUBCASE("Parse Error") {
+		static const char32_t u32str[] = { 0xd800, 0xd800, 0 };
+		String parsed;
+		Error err = parsed.append_utf16(u32str.utf16().get_data());
+		CHECK(err == ERR_PARSE_ERROR);
+	}
 }
 
 TEST_CASE("[String] UTF8 with BOM") {

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -136,17 +136,11 @@ TEST_CASE("[String] UTF16") {
 
 	// 0 length is OK
 	SUBCASE("0 Length") {
+		static const char32_t u32str[] = { 0 };
+		String expected = u32str;
 		String parsed;
-		Error err = parsed.append_utf16({}, 0, false);
+		Error err = parsed.append_utf16(expected.utf16().get_data());
 		CHECK(err == OK);
-	}
-
-	// Parse error for double lead surrogate
-	SUBCASE("Parse Error") {
-		static const char32_t u32str[] = { 0xd800, 0xd800, 0 };
-		String parsed;
-		Error err = parsed.append_utf16(u32str.utf16().get_data());
-		CHECK(err == ERR_PARSE_ERROR);
 	}
 }
 

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -136,10 +136,9 @@ TEST_CASE("[String] UTF16") {
 
 	// 0 length is OK
 	SUBCASE("0 Length") {
-		static const char32_t u32str[] = { 0 };
-		String expected = u32str;
+		static const char16_t u16str[] = {};
 		String parsed;
-		Error err = parsed.append_utf16(expected.utf16().get_data());
+		Error err = parsed.append_utf16(u16str, 0, false);
 		CHECK(err == OK);
 	}
 

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -127,7 +127,7 @@ TEST_CASE("[String] UTF16") {
 		CHECK(String::utf16(cs) == parsed);
 	}
 
-	// Check that error is returned for nullptr data
+	// Check that invalid data error is returned for nullptr data
 	SUBCASE("Invalid data") {
 		String parsed;
 		Error err = parsed.append_utf16(nullptr, 0, false);
@@ -141,6 +141,14 @@ TEST_CASE("[String] UTF16") {
 		String parsed;
 		Error err = parsed.append_utf16(expected.utf16().get_data());
 		CHECK(err == OK);
+	}
+
+	// Parse error for badly formatted surrogates
+	SUBCASE("Parse Error") {
+		static const char16_t u16str[] = { 0x0045, 0x0020, 0x0045, 0x0020, 0x0045, 0x0020, 0xdc00, 0xdc00, 0xdc00, 0xd800, 0xd800, 0 };
+		String parsed;
+		Error err = parsed.append_utf16(u16str);
+		CHECK(err == ERR_PARSE_ERROR);
 	}
 }
 


### PR DESCRIPTION
- Add tests for String::append_utf16 to `test_string.h`, raising branch coverage to 100%
- Add requirement comments to String::append_utf16 in `ustring.cpp`
CLOSES #11 
