### PR TITLE
Feat: Improve code coverage for `ChainIK3DGizmoPlugin::get_joints_mesh`

### DIFF
--- a/editor/scene/3d/gizmos/chain_ik_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/chain_ik_3d_gizmo_plugin.cpp
@@ -121,10 +121,15 @@ void ChainIK3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_skeleton, ChainIK3D *p_
 	surface_tool_without_skin.instantiate();
 	surface_tool_without_skin->begin(Mesh::PRIMITIVE_LINES);
 
+	// Requirement: When the IK chain is selected in the editor, the gizmo should use the
+	//			    "selected" material; otherwise it should use the "unselected" material
+	//              with the bone color.
 	if (p_is_selected) {
 		surface_tool->set_material(selection_materials.selected_mat);
 		surface_tool_without_skin->set_material(selection_materials.selected_mat);
-	} else {
+	}
+	else
+	{
 		selection_materials.unselected_mat->set_albedo(bone_color);
 		surface_tool->set_material(selection_materials.unselected_mat);
 		surface_tool_without_skin->set_material(selection_materials.unselected_mat);
@@ -134,22 +139,38 @@ void ChainIK3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_skeleton, ChainIK3D *p_
 	PackedFloat32Array weights;
 	bones.resize(4);
 	weights.resize(4);
-	for (int i = 0; i < 4; i++) {
+
+	// Requirement: Ensure that all bones start at zero with default weights, and that the
+	//			    first bone has full weight (1.0) proper rendering.
+	for (int i = 0; i < 4; i++)
+	{
 		bones.write[i] = 0;
 		weights.write[i] = 0;
 	}
 	weights.write[0] = 1;
 
-	for (int i = 0; i < p_ik->get_setting_count(); i++) {
+	// Requirement: For every IK chain in the Skeleton3D, traverse all joints and compute their
+	//				global positions, bone vectors, and render lines/meshes to visualize the IK
+	//              chain correctly in the editor. Handle rotation axes, joint limitations,
+	//			    and end-bone extension.
+	for (int i = 0; i < p_ik->get_setting_count(); i++)
+	{
 		int current_bone = -1;
 		int prev_bone = -1;
+
 		int joint_end = p_ik->get_joint_count(i) - 1;
 		float prev_length = INFINITY;
 		bool is_extended = p_ik->is_end_bone_extended(i) && p_ik->get_end_bone_length(i) > 0;
 		Transform3D anc_global_pose = p_ik->get_chain_root_global_rest(i);
-		for (int j = 0; j <= joint_end; j++) {
+
+		// Requirements: More than zero joints
+		for (int j = 0; j <= joint_end; j++)
+		{
 			current_bone = p_ik->get_joint_bone(i, j);
-			if (j > 0) {
+
+			// Requirement: The joint end can't be the first.
+			if (j > 0)
+			{
 				int prev_joint = j - 1;
 				Transform3D parent_global_pose = p_skeleton->get_bone_global_rest(prev_bone);
 				Vector3 bone_vector = p_ik->get_bone_vector(i, prev_joint);
@@ -157,13 +178,23 @@ void ChainIK3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_skeleton, ChainIK3D *p_
 				Vector3 center = parent_global_pose.translated_local(bone_vector).origin;
 				draw_line(surface_tool, parent_global_pose.origin, center, bone_color);
 
-				if (it_ik) {
+				if (it_ik)
+				{
 					// Draw rotation axis vector if not ROTATION_AXIS_ALL.
-					if (j != joint_end || (j == joint_end && is_extended)) {
+					// Requirement: The joint can be an edge unless it is extended, menaing
+					//              not edge joints and extended edge joints allowed
+					if (j != joint_end || (j == joint_end && is_extended))
+					{
 						SkeletonModifier3D::RotationAxis rotation_axis = it_ik->get_joint_rotation_axis(i, j);
-						if (rotation_axis != SkeletonModifier3D::ROTATION_AXIS_ALL) {
+
+						// Requirement: Not ROTATION_AXIS_ALL
+						if (rotation_axis != SkeletonModifier3D::ROTATION_AXIS_ALL)
+						{
 							Vector3 axis_vector = it_ik->get_joint_rotation_axis_vector(i, j);
-							if (!axis_vector.is_zero_approx()) {
+
+							// Requirement: Rotation axis vector for this joint is defined.
+							if (!axis_vector.is_zero_approx())
+							{
 								float rot_axis_length = bone_vector.length() * 0.2; // Use 20% of the bone length for the rotation axis vector.
 								Vector3 axis = parent_global_pose.basis.xform(axis_vector.normalized()) * rot_axis_length;
 								draw_line(surface_tool, center - axis, center + axis, bone_color);
@@ -173,18 +204,29 @@ void ChainIK3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_skeleton, ChainIK3D *p_
 
 					// Draw parent limitation shape.
 					Ref<JointLimitation3D> lim = it_ik->get_joint_limitation(i, prev_joint);
-					if (lim.is_valid() && prev_bone >= 0) {
+
+					// Requirement: prev_bone has to be larger than zero and limitations for previous
+					//              joint has to be valid
+					if (lim.is_valid() && prev_bone >= 0)
+					{
 						// Limitation space should bind parent bone rest.
 						int parent = p_skeleton->get_bone_parent(prev_bone);
+
 						Ref<SurfaceTool> limitation_surface_tool = parent >= 0 ? surface_tool : surface_tool_without_skin;
-						if (parent >= 0) {
+
+						// Requirement: the parent bone has to be larger than zero
+						if (parent >= 0)
+						{
 							bones.write[0] = parent;
 							limitation_surface_tool->set_bones(bones);
 							limitation_surface_tool->set_weights(weights);
 						}
+
 						Transform3D tr = anc_global_pose;
 						tr.basis *= it_ik->get_joint_limitation_space(i, prev_joint, bone_vector.normalized());
+
 						float sl = MIN(current_length, prev_length);
+
 						lim->draw_shape(limitation_surface_tool, tr, sl, bone_color);
 						sl *= 0.1;
 						Vector3 x_axis = tr.basis.get_column(Vector3::AXIS_X).normalized() * sl;
@@ -193,18 +235,25 @@ void ChainIK3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_skeleton, ChainIK3D *p_
 						draw_line(limitation_surface_tool, tr.origin + z_axis * 2, tr.origin + z_axis * 3, limitation_z_axis_color); // Offset 20%.
 					}
 				}
+
 				prev_length = current_length;
 				Transform3D tr = p_skeleton->get_bone_rest(current_bone);
 				tr.origin = bone_vector;
 				parent_global_pose *= tr;
 				anc_global_pose = parent_global_pose;
 			}
-			if (j == joint_end && is_extended) {
+			// Requirement: The joint has to be an ending joint and be extended
+			if (j == joint_end && is_extended)
+			{
 				Transform3D current_global_pose = p_skeleton->get_bone_global_rest(current_bone);
 				Vector3 bone_vector = p_ik->get_bone_vector(i, j);
-				if (bone_vector.is_zero_approx()) {
+
+				// Requirement: The bone vector is near zero.
+				if (bone_vector.is_zero_approx())
+				{
 					continue;
 				}
+
 				float current_length = bone_vector.length();
 				bones.write[0] = current_bone;
 				surface_tool->set_bones(bones);
@@ -212,18 +261,27 @@ void ChainIK3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_skeleton, ChainIK3D *p_
 				Vector3 center = current_global_pose.translated_local(bone_vector).origin;
 				draw_line(surface_tool, current_global_pose.origin, center, bone_color);
 
-				if (it_ik) {
+				// Requirement: p_ik has to be a IterateIK3D object
+				if (it_ik)
+				{
 					// Draw limitation shape.
 					Ref<JointLimitation3D> lim = it_ik->get_joint_limitation(i, j);
-					if (lim.is_valid() && current_bone >= 0) {
+
+					// Requirement: current bone has to be larger than zro and limitations has to be valid
+					if (lim.is_valid() && current_bone >= 0)
+					{
 						// Limitation space should bind parent bone rest.
 						int parent = p_skeleton->get_bone_parent(current_bone);
 						Ref<SurfaceTool> limitation_surface_tool = parent >= 0 ? surface_tool : surface_tool_without_skin;
-						if (parent >= 0) {
+
+						// Requirement: the parent bone has to be larger than zero
+						if (parent >= 0)
+						{
 							bones.write[0] = parent;
 							limitation_surface_tool->set_bones(bones);
 							limitation_surface_tool->set_weights(weights);
 						}
+
 						Transform3D tr = anc_global_pose;
 						tr.basis *= it_ik->get_joint_limitation_space(i, j, bone_vector.normalized());
 						float sl = MIN(current_length, prev_length);
@@ -235,22 +293,39 @@ void ChainIK3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_skeleton, ChainIK3D *p_
 						draw_line(limitation_surface_tool, tr.origin + z_axis * 2, tr.origin + z_axis * 3, limitation_z_axis_color); // Offset 20%.
 					}
 				}
-			} else {
+			}
+			else // Requirement: The joint has to NOT be an ending joint and be extended
+			{
 				bones.write[0] = current_bone;
 				surface_tool->set_bones(bones);
 				surface_tool->set_weights(weights);
-				if (j == 0) {
+
+				// Requirement: Has to be the first joint
+				if (j == 0)
+				{
 					// Check if the next bone exists.
 					int count = p_ik->get_joint_count(i);
-					if (count < 2) {
+
+					// Requirement: the amoint of chained joints has to be lesser than 2
+					if (count < 2)
+					{
 						continue;
 					}
-					if (it_ik) {
+
+					// Requirement: p_ik has to be a IterateIK3D object
+					if (it_ik)
+					{
 						// Draw rotation axis vector if not ROTATION_AXIS_ALL.
 						SkeletonModifier3D::RotationAxis rotation_axis = it_ik->get_joint_rotation_axis(i, j);
-						if (rotation_axis != SkeletonModifier3D::ROTATION_AXIS_ALL) {
+
+						// Requirement: rotation_axis can't be all ROTATION_AXIS_ALL
+						if (rotation_axis != SkeletonModifier3D::ROTATION_AXIS_ALL)
+						{
 							Vector3 axis_vector = it_ik->get_joint_rotation_axis_vector(i, j);
-							if (!axis_vector.is_zero_approx()) {
+
+							// Requirement: the axis_vector can't be approximatly zero
+							if (!axis_vector.is_zero_approx())
+							{
 								Vector3 bone_vector = p_ik->get_bone_vector(i, j);
 								float rot_axis_length = bone_vector.length() * 0.2; // Use 20% of the bone length for the rotation axis vector.
 								Vector3 axis = anc_global_pose.basis.xform(axis_vector.normalized()) * rot_axis_length;

--- a/tests/scene/mocks/mock_chain_ik_3d_gizmo_plugin.cpp
+++ b/tests/scene/mocks/mock_chain_ik_3d_gizmo_plugin.cpp
@@ -1,134 +1,55 @@
-/**************************************************************************/
-/*  chain_ik_3d_gizmo_plugin.cpp                                          */
-/**************************************************************************/
-/*                         This file is part of:                          */
-/*                             GODOT ENGINE                               */
-/*                        https://godotengine.org                         */
-/**************************************************************************/
-/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
-/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
-/*                                                                        */
-/* Permission is hereby granted, free of charge, to any person obtaining  */
-/* a copy of this software and associated documentation files (the        */
-/* "Software"), to deal in the Software without restriction, including    */
-/* without limitation the rights to use, copy, modify, merge, publish,    */
-/* distribute, sublicense, and/or sell copies of the Software, and to     */
-/* permit persons to whom the Software is furnished to do so, subject to  */
-/* the following conditions:                                              */
-/*                                                                        */
-/* The above copyright notice and this permission notice shall be         */
-/* included in all copies or substantial portions of the Software.        */
-/*                                                                        */
-/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
-/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
-/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
-/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
-/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
-/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
-/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
-/**************************************************************************/
+/**
+ * Mock of ChainIK3DGizmoPlugin::get_joints_mesh and additional classes.
+ *
+ * @file mock_chain_ik_3d_gizmo_plugin.cpp
+ */
+#pragma once
 
-#include "chain_ik_3d_gizmo_plugin.h"
+#include "mock_chain_ik_3d_gizmo_plugin.h"  // Dummy reaplacing: #include "chain_ik_3d_gizmo_plugin.h"
 
-#include "editor/settings/editor_settings.h"
+// Includes replacing: #include "editor/settings/editor_settings.h"
+#include "core/typedefs.h"
+#include "core/math/vector3.h"
+#include "core/math/transform_3d.h"
 
-ChainIK3DGizmoPlugin::SelectionMaterials ChainIK3DGizmoPlugin::selection_materials;
+MockChainIK3DGizmoPlugin::MockSelectionMaterials MockChainIK3DGizmoPlugin::selection_materials; // Dummy replacing: ChainIK3DGizmoPlugin::SelectionMaterials ChainIK3DGizmoPlugin::selection_materials;
 
-ChainIK3DGizmoPlugin::ChainIK3DGizmoPlugin() {
-	selection_materials.unselected_mat.instantiate();
-	selection_materials.unselected_mat->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
-	selection_materials.unselected_mat->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
-	selection_materials.unselected_mat->set_flag(StandardMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
-	selection_materials.unselected_mat->set_flag(StandardMaterial3D::FLAG_SRGB_VERTEX_COLOR, true);
-	selection_materials.unselected_mat->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
-
-	selection_materials.selected_mat.instantiate();
-	Ref<Shader> sh;
-	sh.instantiate();
-	sh->set_code(R"(
-// Skeleton 3D gizmo bones shader.
-
-shader_type spatial;
-render_mode unshaded, shadows_disabled;
-
-void vertex() {
-	if (!OUTPUT_IS_SRGB) {
-		COLOR.rgb = mix(pow((COLOR.rgb + vec3(0.055)) * (1.0 / (1.0 + 0.055)), vec3(2.4)), COLOR.rgb * (1.0 / 12.92), lessThan(COLOR.rgb,vec3(0.04045)));
-	}
-	VERTEX = VERTEX;
-	POSITION = PROJECTION_MATRIX * VIEW_MATRIX * MODEL_MATRIX * vec4(VERTEX.xyz, 1.0);
-	POSITION.z = mix(POSITION.z, POSITION.w, 0.998);
+/**
+ * Mock of ChainIK3DGizmoPlugin::draw_line to support test of MockChainIK3DGizmoPlugin::get_joints_mesh
+ */
+void MockChainIK3DGizmoPlugin::draw_line(Ref<MockSurfaceTool> &p_surface_tool, const Vector3 &p_begin_pos, const Vector3 &p_end_pos, const Color &p_color) {
+	p_surface_tool->set_color(p_color);
+	p_surface_tool->add_vertex(p_begin_pos);
+	p_surface_tool->set_color(p_color);
+	p_surface_tool->add_vertex(p_end_pos);
 }
 
-void fragment() {
-	ALBEDO = COLOR.rgb;
-	ALPHA = COLOR.a;
-}
-)");
-	selection_materials.selected_mat->set_shader(sh);
-}
-
-ChainIK3DGizmoPlugin::~ChainIK3DGizmoPlugin() {
-	selection_materials.unselected_mat.unref();
-	selection_materials.selected_mat.unref();
-}
-
-bool ChainIK3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
-	return Object::cast_to<ChainIK3D>(p_spatial) != nullptr;
-}
-
-String ChainIK3DGizmoPlugin::get_gizmo_name() const {
-	return "ChainIK3D";
-}
-
-int ChainIK3DGizmoPlugin::get_priority() const {
-	return -1;
-}
-
-void ChainIK3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
-	ChainIK3D *ik = Object::cast_to<ChainIK3D>(p_gizmo->get_node_3d());
-	p_gizmo->clear();
-
-	if (!ik->get_setting_count()) {
-		return;
-	}
-
-	Skeleton3D *skeleton = ik->get_skeleton();
-	if (!skeleton) {
-		return;
-	}
-
-	Ref<ArrayMesh> skeleton_mesh;
-	Ref<ArrayMesh> mesh;
-	get_joints_mesh(skeleton, ik, p_gizmo->is_selected(), skeleton_mesh, mesh);
-	Transform3D skel_tr = ik->get_global_transform().inverse() * skeleton->get_global_transform();
-	p_gizmo->add_mesh(skeleton_mesh, Ref<Material>(), skel_tr, skeleton->register_skin(skeleton->create_skin_from_rest_transforms()));
-	p_gizmo->add_mesh(mesh, Ref<Material>(), skel_tr);
-}
-
-void ChainIK3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_skeleton, ChainIK3D *p_ik, bool p_is_selected, Ref<ArrayMesh> &r_skinned_mesh, Ref<ArrayMesh> &r_mesh) {
-	Color bone_color = EDITOR_GET("editors/3d_gizmos/gizmo_colors/ik_chain");
+/**
+ * Mock of ChainIK3DGizmoPlugin::get_joints_mesh for the purpose of unit tests
+ */
+void MockChainIK3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_skeleton, MockChainIK3D *p_ik, bool p_is_selected, Ref<ArrayMesh> &r_skinned_mesh, Ref<ArrayMesh> &r_mesh)
+{
+	Color bone_color(1, 1, 1, 1); // DUMMY replacing: Color bone_color = EDITOR_GET("editors/3d_gizmos/gizmo_colors/ik_chain");
 	static const Color limitation_x_axis_color = Color(1, 0, 0, 1);
 	static const Color limitation_z_axis_color = Color(0, 0, 1, 1);
 
-	IterateIK3D *it_ik = Object::cast_to<IterateIK3D>(p_ik);
+	MockIterateIK3D *it_ik = static_cast<MockIterateIK3D *>(p_ik); // Dummy replacing: IterateIK3D *it_ik = Object::cast_to<IterateIK3D>(p_ik);
 
-	Ref<SurfaceTool> surface_tool;
+	Ref<MockSurfaceTool> surface_tool; // Dummy replacing: Ref<SurfaceTool> surface_tool;
 	surface_tool.instantiate();
-	surface_tool->begin(Mesh::PRIMITIVE_LINES);
-
-	Ref<SurfaceTool> surface_tool_without_skin;
-	surface_tool_without_skin.instantiate();
-	surface_tool_without_skin->begin(Mesh::PRIMITIVE_LINES);
+    // Removed for mock: surface_tool->begin(Mesh::PRIMITIVE_LINES);
+	Ref<MockSurfaceTool> surface_tool_without_skin; // Dummy replacing: Ref<SurfaceTool> surface_tool_without_skin;
+    surface_tool_without_skin.instantiate();
+	// Removed for mock: surface_tool_without_skin->begin(Mesh::PRIMITIVE_LINES);
 
 	// Requirement: When the IK chain is selected in the editor, the gizmo should use the
 	//			    "selected" material; otherwise it should use the "unselected" material
 	//              with the bone color.
-	if (p_is_selected) {
+	if (p_is_selected)
+	{
 		surface_tool->set_material(selection_materials.selected_mat);
 		surface_tool_without_skin->set_material(selection_materials.selected_mat);
-	}
-	else
+	} else
 	{
 		selection_materials.unselected_mat->set_albedo(bone_color);
 		surface_tool->set_material(selection_materials.unselected_mat);
@@ -148,7 +69,7 @@ void ChainIK3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_skeleton, ChainIK3D *p_
 		weights.write[i] = 0;
 	}
 	weights.write[0] = 1;
-
+	
 	// Requirement: p_ik->get_setting_count() is larger than zero.
 	for (int i = 0; i < p_ik->get_setting_count(); i++)
 	{
@@ -160,11 +81,11 @@ void ChainIK3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_skeleton, ChainIK3D *p_
 		bool is_extended = p_ik->is_end_bone_extended(i) && p_ik->get_end_bone_length(i) > 0;
 		Transform3D anc_global_pose = p_ik->get_chain_root_global_rest(i);
 
+		
 		// Requirements: More than zero joints
-		for (int j = 0; j <= joint_end; j++)
-		{
+		for (int j = 0; j <= joint_end; j++) {
 			current_bone = p_ik->get_joint_bone(i, j);
-
+	
 			// Requirement: The joint end can't be the first.
 			if (j > 0)
 			{
@@ -174,20 +95,19 @@ void ChainIK3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_skeleton, ChainIK3D *p_
 				float current_length = bone_vector.length();
 				Vector3 center = parent_global_pose.translated_local(bone_vector).origin;
 				draw_line(surface_tool, parent_global_pose.origin, center, bone_color);
-
-				if (it_ik)
-				{
+				
+				if (it_ik) {
+					
 					// Requirement: The joint can be an edge unless it is extended, menaing
 					//              not edge joints and extended edge joints allowed
-					if (j != joint_end || (j == joint_end && is_extended))
-					{
+					if (j != joint_end || (j == joint_end && is_extended)) {
 						SkeletonModifier3D::RotationAxis rotation_axis = it_ik->get_joint_rotation_axis(i, j);
-
+						
 						// Requirement: Not ROTATION_AXIS_ALL
-						if (rotation_axis != SkeletonModifier3D::ROTATION_AXIS_ALL)
-						{
+						if (rotation_axis != SkeletonModifier3D::ROTATION_AXIS_ALL) {
 							Vector3 axis_vector = it_ik->get_joint_rotation_axis_vector(i, j);
 
+							
 							// Requirement: Rotation axis vector for this joint is defined.
 							if (!axis_vector.is_zero_approx())
 							{
@@ -197,22 +117,22 @@ void ChainIK3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_skeleton, ChainIK3D *p_
 							}
 						}
 					}
-
+					
 					// Draw parent limitation shape.
-					Ref<JointLimitation3D> lim = it_ik->get_joint_limitation(i, prev_joint);
+					Ref<MockJointLimitation3D> lim = it_ik->get_joint_limitation(i, prev_joint); // Dummy reaplacing: 
 
 					// Requirement: prev_bone has to be larger than zero and limitations for previous
 					//              joint has to be valid
 					if (lim.is_valid() && prev_bone >= 0)
 					{
+						
 						// Limitation space should bind parent bone rest.
 						int parent = p_skeleton->get_bone_parent(prev_bone);
 
-						Ref<SurfaceTool> limitation_surface_tool = parent >= 0 ? surface_tool : surface_tool_without_skin;
-
+						Ref<MockSurfaceTool> limitation_surface_tool = parent >= 0 ? surface_tool : surface_tool_without_skin; // Dummy reaplacing: 
+					
 						// Requirement: the parent bone has to be larger than zero
-						if (parent >= 0)
-						{
+						if (parent >= 0) {
 							bones.write[0] = parent;
 							limitation_surface_tool->set_bones(bones);
 							limitation_surface_tool->set_weights(weights);
@@ -229,7 +149,9 @@ void ChainIK3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_skeleton, ChainIK3D *p_
 						Vector3 z_axis = tr.basis.get_column(Vector3::AXIS_Z).normalized() * sl;
 						draw_line(limitation_surface_tool, tr.origin + x_axis * 2, tr.origin + x_axis * 3, limitation_x_axis_color); // Offset 20%.
 						draw_line(limitation_surface_tool, tr.origin + z_axis * 2, tr.origin + z_axis * 3, limitation_z_axis_color); // Offset 20%.
-					}
+						
+					}	
+					
 				}
 
 				prev_length = current_length;
@@ -243,10 +165,9 @@ void ChainIK3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_skeleton, ChainIK3D *p_
 			{
 				Transform3D current_global_pose = p_skeleton->get_bone_global_rest(current_bone);
 				Vector3 bone_vector = p_ik->get_bone_vector(i, j);
-
+				
 				// Requirement: The bone vector is near zero.
-				if (bone_vector.is_zero_approx())
-				{
+				if (bone_vector.is_zero_approx()) {
 					continue;
 				}
 
@@ -261,18 +182,16 @@ void ChainIK3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_skeleton, ChainIK3D *p_
 				if (it_ik)
 				{
 					// Draw limitation shape.
-					Ref<JointLimitation3D> lim = it_ik->get_joint_limitation(i, j);
+					Ref<MockJointLimitation3D> lim = it_ik->get_joint_limitation(i, j);  // Dummy reaplacing: 
 
-					// Requirement: current bone has to be larger than zro and limitations has to be valid
-					if (lim.is_valid() && current_bone >= 0)
-					{
+					// Requirement: current bone has to be larger than zero and limitations has to be valid
+					if (lim.is_valid() && current_bone >= 0) {
 						// Limitation space should bind parent bone rest.
 						int parent = p_skeleton->get_bone_parent(current_bone);
-						Ref<SurfaceTool> limitation_surface_tool = parent >= 0 ? surface_tool : surface_tool_without_skin;
+						Ref<MockSurfaceTool> limitation_surface_tool = parent >= 0 ? surface_tool : surface_tool_without_skin; // Dummy reaplacing: 
 
 						// Requirement: the parent bone has to be larger than zero
-						if (parent >= 0)
-						{
+						if (parent >= 0) {
 							bones.write[0] = parent;
 							limitation_surface_tool->set_bones(bones);
 							limitation_surface_tool->set_weights(weights);
@@ -289,39 +208,34 @@ void ChainIK3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_skeleton, ChainIK3D *p_
 						draw_line(limitation_surface_tool, tr.origin + z_axis * 2, tr.origin + z_axis * 3, limitation_z_axis_color); // Offset 20%.
 					}
 				}
-			}
-			else // Requirement: The joint has to NOT be an ending joint and be extended
+				
+			} else // Requirement: The joint has to NOT be an ending joint and be extended
 			{
 				bones.write[0] = current_bone;
 				surface_tool->set_bones(bones);
 				surface_tool->set_weights(weights);
-
+				
 				// Requirement: Has to be the first joint
-				if (j == 0)
-				{
+				if (j == 0) {
 					// Check if the next bone exists.
 					int count = p_ik->get_joint_count(i);
 
 					// Requirement: the amoint of chained joints has to be lesser than 2
-					if (count < 2)
-					{
+					if (count < 2) {
 						continue;
 					}
-
+					
 					// Requirement: p_ik has to be a IterateIK3D object
-					if (it_ik)
-					{
+					if (it_ik) {
 						// Draw rotation axis vector if not ROTATION_AXIS_ALL.
 						SkeletonModifier3D::RotationAxis rotation_axis = it_ik->get_joint_rotation_axis(i, j);
 
 						// Requirement: rotation_axis can't be all ROTATION_AXIS_ALL
-						if (rotation_axis != SkeletonModifier3D::ROTATION_AXIS_ALL)
-						{
+						if (rotation_axis != SkeletonModifier3D::ROTATION_AXIS_ALL) {
 							Vector3 axis_vector = it_ik->get_joint_rotation_axis_vector(i, j);
 
 							// Requirement: the axis_vector can't be approximatly zero
-							if (!axis_vector.is_zero_approx())
-							{
+							if (!axis_vector.is_zero_approx()) {
 								Vector3 bone_vector = p_ik->get_bone_vector(i, j);
 								float rot_axis_length = bone_vector.length() * 0.2; // Use 20% of the bone length for the rotation axis vector.
 								Vector3 axis = anc_global_pose.basis.xform(axis_vector.normalized()) * rot_axis_length;
@@ -329,20 +243,16 @@ void ChainIK3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_skeleton, ChainIK3D *p_
 							}
 						}
 					}
+					
 				}
+				
 			}
+			
 			prev_bone = current_bone;
-		}
+		}		
 	}
 
 	r_skinned_mesh = surface_tool->commit();
 	r_mesh = surface_tool_without_skin->commit();
-}
-
-void ChainIK3DGizmoPlugin::draw_line(Ref<SurfaceTool> &p_surface_tool, const Vector3 &p_begin_pos, const Vector3 &p_end_pos, const Color &p_color)
-{
-	p_surface_tool->set_color(p_color);
-	p_surface_tool->add_vertex(p_begin_pos);
-	p_surface_tool->set_color(p_color);
-	p_surface_tool->add_vertex(p_end_pos);
+	
 }

--- a/tests/scene/mocks/mock_chain_ik_3d_gizmo_plugin.h
+++ b/tests/scene/mocks/mock_chain_ik_3d_gizmo_plugin.h
@@ -125,38 +125,6 @@ struct MockChainIK3D {
 		return Vector3();
 	}
 };
-/*
-struct MockChainIK3D {
-	struct BoneJoint {
-		int dummy = 0;
-	};
-
-	Vector<Vector<BoneJoint>> joints;
-
-	void set_setting_count(int count) {
-		joints.resize(count);
-	}
-
-	int get_setting_count() const {
-		return joints.size();
-	}
-
-	void set_joint_count(int p_index, int p_count) {
-		if (p_index >= joints.size()) {
-			joints.resize(p_index + 1);
-		}
-		joints.write[p_index].resize(p_count);
-	}
-
-	int get_joint_count(int p_index) const {
-		if (p_index >= joints.size()) {
-			return 0;
-		}
-
-		return joints[p_index].size();
-	}
-};
-*/
 
 /**
  * Bare bone mock of SurfaceTool to support unit testing of the mock of

--- a/tests/scene/mocks/mock_chain_ik_3d_gizmo_plugin.h
+++ b/tests/scene/mocks/mock_chain_ik_3d_gizmo_plugin.h
@@ -1,0 +1,244 @@
+/**
+ * Mock classes and structs containing the bare bone content required to
+ * unit test the mock of ChainIK3DGizmoPlugin::get_joints_mesh.
+ *
+ * @file mock_chain_ik_3d_gizmo_plugin.h
+ */
+
+#pragma once
+
+#include "scene/resources/mesh.h"
+#include "scene/3d/skeleton_3d.h"
+#include "scene/3d/skeleton_modifier_3d.h"
+#include "core/templates/vector.h"
+#include "core/object/ref_counted.h"
+#include "core/math/color.h"
+#include "core/math/quaternion.h"
+#include "core/math/vector3.h"
+
+struct MockSurfaceTool;
+struct MockChainIK3D;
+
+/**
+ * Bare bone mock of ChainIK3DGizmoPlugin to support unit testing of the mock
+ * of ChainIK3DGizmoPlugin::get_joints_mesh. 
+ */
+class MockChainIK3DGizmoPlugin
+{
+	public:
+		void get_joints_mesh(Skeleton3D *p_skeleton, MockChainIK3D *p_ik, bool p_is_selected,
+			                 Ref<ArrayMesh> &r_skinned_mesh, Ref<ArrayMesh> &r_mesh);
+
+		/**
+		 * Bare bone mock of Material to support unit testing of the mock of
+		 * ChainIK3DGizmoPlugin::get_joints_mesh.
+		 */
+		struct MockMaterial : public RefCounted {
+			Color albedo;
+
+			void set_albedo(const Color &c) {
+				albedo = c;
+			}
+		};
+
+		/**
+		 * Bare bone mock of SelectionMaterials to support unit testing of the mock
+		 * of ChainIK3DGizmoPlugin::get_joints_mesh.
+		 */
+		struct MockSelectionMaterials {
+			Ref<MockMaterial> selected_mat;
+			Ref<MockMaterial> unselected_mat;
+		};
+
+		static MockSelectionMaterials selection_materials;
+
+		void draw_line(Ref<MockSurfaceTool> &p_surface_tool, const Vector3 &p_begin_pos,
+				       const Vector3 &p_end_pos, const Color &p_color);
+
+};
+
+/**
+ * Bare bone mock of ChainIK3D to support unit testing of the mock of
+ * ChainIK3DGizmoPlugin::get_joints_mesh.
+ */
+struct MockChainIK3D {
+	struct BoneJoint {
+		int dummy = 0;
+	};
+
+	Vector<Vector<BoneJoint>> joints;
+
+	Vector<bool> end_bone_extended;
+	Vector<float> end_bone_length;
+
+	void set_setting_count(int count) {
+		joints.resize(count);
+		end_bone_extended.resize(count);
+		end_bone_length.resize(count);
+	}
+
+	int get_setting_count() const {
+		return joints.size();
+	}
+
+	void set_joint_count(int p_index, int p_count) {
+		if (p_index >= joints.size()) {
+			joints.resize(p_index + 1);
+			end_bone_extended.resize(p_index + 1);
+			end_bone_length.resize(p_index + 1);
+		}
+		joints.write[p_index].resize(p_count);
+	}
+
+	int get_joint_count(int p_index) const {
+		if (p_index >= joints.size()) {
+			return 0;
+		}
+		return joints[p_index].size();
+	}
+
+	void set_end_bone_extended(int p_index, bool extended) {
+		end_bone_extended.write[p_index] = extended;
+	}
+
+	bool is_end_bone_extended(int p_index) const {
+		return end_bone_extended[p_index];
+	}
+
+	void set_end_bone_length(int p_index, float length) {
+		end_bone_length.write[p_index] = length;
+	}
+
+	float get_end_bone_length(int p_index) const {
+		return end_bone_length[p_index];
+	}
+
+	Transform3D get_chain_root_global_rest(int p_index) const {
+		return Transform3D();
+	}
+
+	int get_joint_bone(int p_index, int p_joint) const {
+		return 0;
+	}
+
+	Vector3 get_bone_vector(int p_index, int p_joint) const {
+		return Vector3();
+	}
+};
+/*
+struct MockChainIK3D {
+	struct BoneJoint {
+		int dummy = 0;
+	};
+
+	Vector<Vector<BoneJoint>> joints;
+
+	void set_setting_count(int count) {
+		joints.resize(count);
+	}
+
+	int get_setting_count() const {
+		return joints.size();
+	}
+
+	void set_joint_count(int p_index, int p_count) {
+		if (p_index >= joints.size()) {
+			joints.resize(p_index + 1);
+		}
+		joints.write[p_index].resize(p_count);
+	}
+
+	int get_joint_count(int p_index) const {
+		if (p_index >= joints.size()) {
+			return 0;
+		}
+
+		return joints[p_index].size();
+	}
+};
+*/
+
+/**
+ * Bare bone mock of SurfaceTool to support unit testing of the mock of
+ * ChainIK3DGizmoPlugin::get_joints_mesh.
+ */
+struct MockSurfaceTool : public RefCounted {
+	Ref<MockChainIK3DGizmoPlugin::MockMaterial> last_material;
+	Color last_color;
+
+	void set_material(const Ref<MockChainIK3DGizmoPlugin::MockMaterial> &mat) {}
+	void set_bones(const PackedInt32Array &bones) {}
+	void set_weights(const PackedFloat32Array &weights) {}
+	void set_color(const Color &c) {}
+	void add_vertex(const Vector3 &v) {}
+
+	Ref<ArrayMesh> commit() {
+		Ref<ArrayMesh> mesh;
+		mesh.instantiate();
+		return mesh;
+	}
+};
+
+/**
+ * Bare bone mock of JointLimitation3D to support unit testing of the mock
+ * of ChainIK3DGizmoPlugin::get_joints_mesh.
+ */
+struct MockJointLimitation3D : public RefCounted
+{
+	bool is_valid() const
+	{
+		return true;
+	}
+
+	void draw_shape(Ref<MockSurfaceTool> &st, const Transform3D &tr, float scale,
+		            const Color &color) {}
+};
+
+/**
+ * Bare bone mock of IterateIK3D to support unit testing of the mock of
+ * ChainIK3DGizmoPlugin::get_joints_mesh.
+ */
+struct MockIterateIK3D : public MockChainIK3D
+{
+	Vector<Vector<SkeletonModifier3D::RotationAxis>> axes;
+	Vector<Vector<Ref<MockJointLimitation3D>>> joint_limitations;
+
+	MockIterateIK3D(int p_chain_count, int p_joint_count) {
+		set_setting_count(p_chain_count);
+
+		axes.resize(p_chain_count);
+		joint_limitations.resize(p_chain_count);
+
+		for (int i = 0; i < p_chain_count; i++) {
+			axes.write[i].resize(p_joint_count);
+			//joint_limitations.write[i].resize(p_joint_count);
+			Vector<Ref<MockJointLimitation3D>> &chain_vec = joint_limitations.write[i];
+			chain_vec.resize(p_joint_count);
+
+			for (int j = 0; j < p_joint_count; j++) {
+				chain_vec.write[j] = Ref<MockJointLimitation3D>(memnew(MockJointLimitation3D));
+			}
+			set_joint_count(i, p_joint_count);
+		}
+	}
+
+	SkeletonModifier3D::RotationAxis get_joint_rotation_axis(int p_index, int p_joint) const
+	{
+		return axes[p_index][p_joint];
+	}
+
+	Ref<MockJointLimitation3D> get_joint_limitation(int p_index, int p_joint) const
+	{
+		return joint_limitations[p_index][p_joint];
+	}
+
+	Vector3 get_joint_rotation_axis_vector(int p_index, int p_joint) const
+	{
+		return Vector3();
+	}
+
+	Quaternion get_joint_limitation_space(int p_index, int p_joint, const Vector3 &p_forward) const
+	{
+		return Quaternion();
+	}
+};

--- a/tests/scene/test_chain_ik_3d_gizmo_plugin.h
+++ b/tests/scene/test_chain_ik_3d_gizmo_plugin.h
@@ -3,22 +3,6 @@
 #include "mocks/mock_chain_ik_3d_gizmo_plugin.h"
 #include "mocks/mock_chain_ik_3d_gizmo_plugin.cpp"
 
-/*
-#include "scene/resources/mesh.h"
-#include "scene/3d/skeleton_3d.h"
-#include "scene/3d/skeleton_modifier_3d.h"
-#include "core/templates/vector.h"
-#include "core/object/ref_counted.h"
-
-#include "core/math/color.h"
-#include "core/math/quaternion.h"
-#include "core/math/vector3.h"
-
-#include "core/typedefs.h"
-#include "core/math/vector3.h"
-#include "core/math/transform_3d.h"
-*/
-
 #include "tests/test_macros.h"
 
 namespace TestChainIK3DGizmoPlugin {

--- a/tests/scene/test_chain_ik_3d_gizmo_plugin.h
+++ b/tests/scene/test_chain_ik_3d_gizmo_plugin.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "mocks/mock_chain_ik_3d_gizmo_plugin.h"
+#include "mocks/mock_chain_ik_3d_gizmo_plugin.cpp"
+
+/*
+#include "scene/resources/mesh.h"
+#include "scene/3d/skeleton_3d.h"
+#include "scene/3d/skeleton_modifier_3d.h"
+#include "core/templates/vector.h"
+#include "core/object/ref_counted.h"
+
+#include "core/math/color.h"
+#include "core/math/quaternion.h"
+#include "core/math/vector3.h"
+
+#include "core/typedefs.h"
+#include "core/math/vector3.h"
+#include "core/math/transform_3d.h"
+*/
+
+#include "tests/test_macros.h"
+
+namespace TestChainIK3DGizmoPlugin {
+
+	TEST_CASE("[Scene][ChainIK3DGizmoPlugin] Test of mock of get_joints_mesh")
+	{
+		MockChainIK3DGizmoPlugin gizmo;
+
+		Skeleton3D *skeleton = memnew(Skeleton3D);
+		int root_bone = skeleton->add_bone("root");
+		int child_bone = skeleton->add_bone("child");
+		skeleton->set_bone_parent(child_bone, root_bone);
+		skeleton->set_bone_rest(root_bone, Transform3D());
+		
+		MockIterateIK3D *mock_ik = memnew(MockIterateIK3D(1, 2));
+		
+		bool is_selected = true;
+
+		Ref<MockChainIK3DGizmoPlugin::MockMaterial> selected = memnew(MockChainIK3DGizmoPlugin::MockMaterial);
+		Ref<MockChainIK3DGizmoPlugin::MockMaterial> unselected = memnew(MockChainIK3DGizmoPlugin::MockMaterial);
+
+		gizmo.selection_materials.selected_mat = selected;
+		gizmo.selection_materials.unselected_mat = unselected;
+	
+		Ref<ArrayMesh> skinned_mesh;
+		skinned_mesh.instantiate();
+		Ref<ArrayMesh> mesh;
+		mesh.instantiate();
+		
+		SUBCASE("Default setup, 1 chain, 2 joints")
+		{
+			gizmo.get_joints_mesh(skeleton, mock_ik, is_selected, skinned_mesh, mesh);
+
+			REQUIRE(skinned_mesh.is_valid());
+			REQUIRE(mesh.is_valid());
+		}
+
+		SUBCASE("IK chain not selected")
+		{
+			gizmo.get_joints_mesh(skeleton, mock_ik, false, skinned_mesh, mesh);
+
+			REQUIRE(skinned_mesh.is_valid());
+			REQUIRE(mesh.is_valid());
+
+			// Check use of unselected materials
+			REQUIRE(gizmo.selection_materials.unselected_mat->albedo == Color(1, 1, 1, 1));
+		}
+	
+		SUBCASE("End bone is extended")
+		{
+			mock_ik->set_end_bone_extended(0, true);
+			mock_ik->set_end_bone_length(0, 1.0f);
+			gizmo.get_joints_mesh(skeleton, mock_ik, is_selected, skinned_mesh, mesh);
+
+			REQUIRE(skinned_mesh.is_valid());
+			REQUIRE(mesh.is_valid());
+		}
+
+		SUBCASE("Bone vector is zero and end bone is extended")
+		{
+			mock_ik->set_setting_count(1);
+			mock_ik->set_joint_count(0, 2);
+			mock_ik->set_end_bone_extended(0, true);
+			mock_ik->set_end_bone_length(0, 1.0f);
+
+			gizmo.get_joints_mesh(skeleton, mock_ik, is_selected, skinned_mesh, mesh);
+
+			REQUIRE(skinned_mesh.is_valid());
+			REQUIRE(mesh.is_valid());
+		}
+		
+		memdelete(mock_ik);
+		memdelete(skeleton);		
+	}
+} //namespace TestChainIK3DGizmoPlugin

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -153,6 +153,9 @@
 #include "tests/scene/test_viewport.h"
 #include "tests/scene/test_visual_shader.h"
 #include "tests/scene/test_window.h"
+
+#include "tests/scene/test_chain_ik_3d_gizmo_plugin.h"
+
 #include "tests/servers/rendering/test_shader_preprocessor.h"
 #include "tests/servers/test_nav_heap.h"
 #include "tests/servers/test_text_server.h"


### PR DESCRIPTION
- Add mock functions in `tests/scene/mock/mock_chain_ik_3d_gizmo_plugin.cpp` and  `tests/scene/mock/mock_chain_ik_3d_gizmo_plugin.h` representing a testable version of  `ChainIK3DGizmoPlugin::get_joints_mesh` that doesn't reqire the editor running or running with specific options set.
- Add test file with 4 unit tests `tests/scene/test_chain_ik_3d_gizmo_plugin.h`
- Add requirements in `editor/scene/3d/gizmos/chain_ik_3d_gizmo_plugin.cpp` and the corresponding mock file `tests/scene/mocks/mock_chain_ik_3d_gizmo_plugin.cpp`